### PR TITLE
Remove outdated conda_build_config.yaml

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,0 @@
-c_compiler:                    # [win]
-  - vs2017                     # [win]
-cxx_compiler:                  # [win]
-  - vs2017                     # [win]
-vc:                            # [win]
-  - 14                         # [win]
-python:                        # [win]
-  - 3.7                        # [win]


### PR DESCRIPTION
This removes the outdated build config. As `vs2017` is now the default, this changes nothing in the build BUT it unblocks the bot to make PRs to this feedstock again.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
